### PR TITLE
Gem configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,18 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-# initialize an instance of the Client with your API key or
-# set an Environment Variable WEBCEO_API_KEY and initialize client without passing it to the client
-client = Webceo::Api::Client.new('your_api_key')
+
+# Configure the gem
+Webceo.configure do |config|
+  # set the api_key option as per your convenience, for example using environment variables
+  config.api_key = ENV['WEBCEO_API_KEY']
+end
+
+# initialize an instance of the Client
+client = Webceo::Api::Client.new
+
+# get the list of all methods
+client.list_methods # => ['get_projects', 'get_project', ...]
 
 # get list of all the projects, see api reference
 client.get_projects({ :id => 'my_request_id' })

--- a/lib/webceo.rb
+++ b/lib/webceo.rb
@@ -4,9 +4,21 @@ require 'httparty'
 require 'multi_json'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'webceo/api'
-require 'webceo/api/request'
-require 'webceo/api/response'
-require 'webceo/api/error'
-require 'webceo/api/client'
+require 'webceo/configuration'
 
-module Webceo; end # end of module Webceo
+module Webceo
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Webceo::Configuration.new
+    yield(configuration)
+  end
+
+  def self.reset
+    self.configuration = Webceo::Configuration.new
+  end
+
+end # end of module Webceo

--- a/lib/webceo/api.rb
+++ b/lib/webceo/api.rb
@@ -1,3 +1,8 @@
+require 'webceo/api/request'
+require 'webceo/api/response'
+require 'webceo/api/error'
+require 'webceo/api/client'
+
 module Webceo
 
   API_METHODS = YAML.load_file('./lib/webceo/api_methods.yml')

--- a/lib/webceo/api/client.rb
+++ b/lib/webceo/api/client.rb
@@ -14,13 +14,7 @@ module Webceo
       #
       # Intializes an instance of Client to make api calls
       #
-      # It accepts an api_key or uses the one set in the environment variable WEBCEO_API_KEY
-      #
-      # @param [String] api_key Webceo API Key
-      #
-      def initialize(api_key = nil)
-        self.class.default_options.merge!({ api_key: (api_key || ENV['WEBCEO_API_KEY']) })
-      end
+      def initialize; end
 
       #
       # It lists names of all the available API methods on the Webceo API Reference

--- a/lib/webceo/api/request.rb
+++ b/lib/webceo/api/request.rb
@@ -33,7 +33,7 @@ module Webceo
       def to_json
         MultiJson.dump({
           method: @method_name.to_s,
-          key: Webceo::Api::Client.default_options[:api_key],
+          key: Webceo.configuration.api_key,
           id: @data[:id],
           data: @data
         })

--- a/lib/webceo/configuration.rb
+++ b/lib/webceo/configuration.rb
@@ -1,0 +1,22 @@
+module Webceo
+  #
+  # Class Configuration provides ability to set webceo specific configurations
+  #
+  # @author Agnel Waghela <agnelwaghela@gmail.com>
+  #
+  class Configuration
+
+    #
+    # @!attribute [rw] api_key
+    #   @return [String] API Key required to be present along with the api request
+    attr_accessor :api_key
+
+    #
+    # Initialize default attribute values
+    #
+    #
+    def initialize
+      @api_key = nil
+    end
+  end # end of class Configuration
+end # end of module Webceo


### PR DESCRIPTION
- Provides ability to set configuration for the gem 
- Passing the api_key as a parameter when initializing `Webceo::Api::Client` is no longer supported [Breaking Change]
- You need to set the api_key using the Webceo Configuration -

```ruby
Webceo.configure do |config|
  config.api_key = ENV['WEBCEO_API_KEY']
end
```

